### PR TITLE
Add a generic warp controller class for all transformations. Bugfix Barrel, Perspective & other warps (7).

### DIFF
--- a/torqueo/__init__.py
+++ b/torqueo/__init__.py
@@ -11,4 +11,6 @@ __version__ = '0.0.0'
 
 from .base import WarpTransform
 from .plots import show
-from .transforms import Fisheye
+from .transforms import Fisheye, Swirl, BarrelDistortion, Pincushion, Stretching, Compression, Twirl, Wave, \
+    Spherize, Bulge, Implosion, Pinch, Punch, Shear, PerspectiveWarp
+from .controller import WarpController

--- a/torqueo/controller.py
+++ b/torqueo/controller.py
@@ -28,7 +28,7 @@ class WarpController():
                         "Stretching": lambda x: torch.linspace(0, 0.8, 6)[x], 
                         "Compression": lambda x: torch.linspace(0, 2, 6)[x], 
                         "Twirl": lambda x: torch.linspace(0, 1, 6)[x], 
-                        "Wave": lambda x: torch.linspace(0, 1.5, 6)[x], 
+                        "Wave": lambda x: torch.linspace(0, 1.8, 6)[x], 
                         "Spherize": lambda x: torch.linspace(0, 1.2, 6)[x], 
                         "Bulge": lambda x: torch.linspace(1, 3, 6)[x], 
                         "Implosion": lambda x: torch.linspace(0.5, 1, 6)[5-x], 

--- a/torqueo/controller.py
+++ b/torqueo/controller.py
@@ -24,18 +24,18 @@ class WarpController():
         self.mapping_dict = {"Fisheye": lambda x: torch.linspace(0, 1, 6)[x], 
                         "Swirl": lambda x: torch.linspace(0, 1, 6)[x], 
                         "BarrelDistortion": lambda x: torch.linspace(0, 1, 6)[x], 
-                        "Pincushion": lambda x: torch.linspace(0, 1, 6)[x], 
-                        "Stretching": lambda x: torch.linspace(0, 1, 6)[x], 
-                        "Compression": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Pincushion": lambda x: torch.linspace(0, 0.9, 6)[x], 
+                        "Stretching": lambda x: torch.linspace(0, 0.8, 6)[x], 
+                        "Compression": lambda x: torch.linspace(0, 2, 6)[x], 
                         "Twirl": lambda x: torch.linspace(0, 1, 6)[x], 
-                        "Wave": lambda x: torch.linspace(1, 4, 6)[x], 
-                        "Spherize": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Wave": lambda x: torch.linspace(1, 3, 6)[x], 
+                        "Spherize": lambda x: torch.linspace(0, 1.2, 6)[x], 
                         "Bulge": lambda x: torch.linspace(1, 3, 6)[x], 
-                        "Implosion": lambda x: torch.linspace(0, 1, 6)[x], 
-                        "Pinch": lambda x: torch.linspace(0, 1, 6)[x], 
-                        "Punch": lambda x: torch.linspace(0, 1, 6)[x], 
-                        "Shear": lambda x: torch.linspace(0, 1, 6)[x], 
-                        "PerspectiveWarp": lambda x: torch.linspace(0, 1, 6)[x] 
+                        "Implosion": lambda x: torch.linspace(0.5, 1, 6)[5-x], 
+                        "Pinch": lambda x: torch.linspace(0, 0.6, 6)[x], 
+                        "Punch": lambda x: torch.linspace(0, 0.7, 6)[x], 
+                        "Shear": lambda x: torch.linspace(0, 1.2, 6)[x], 
+                        "PerspectiveWarp": lambda x: torch.linspace(0, 0.9, 6)[x] 
                         }
 
     def __call__(self, distortion_level=0, **kwargs): 

--- a/torqueo/controller.py
+++ b/torqueo/controller.py
@@ -1,0 +1,59 @@
+import torch
+import torch.nn.functional as F
+
+class WarpController(): 
+    """
+    This class wraps the WarpTransform subclass by making it an object of this class. 
+    The user can now input distortion levels from 0 to 5 and they will automatically be translated to corresponding strength of distortion arguments for warps. 
+
+    Parameters
+    ----------
+    warp_transform: WarpTransform
+        The particular warping class that we want a controller over. Example: Fisheye, Swirl. 
+
+    Example Usage
+    -------------
+    SwirlController = WarpController(Swirl)
+    swirl_transformer = SwirlController(1, radius=1) #or, SwirlController(distortion_level=1, radius=1)
+
+    The args following distortion_level need to be keyword arguments. 
+    """
+    def __init__(self, warp_transform):
+        self.warp_transform = warp_transform
+        self.class_name = warp_transform.__name__
+        self.mapping_dict = {"Fisheye": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Swirl": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "BarrelDistortion": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Pincushion": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Stretching": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Compression": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Twirl": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Wave": lambda x: torch.linspace(1, 4, 6)[x], 
+                        "Spherize": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Bulge": lambda x: torch.linspace(1, 3, 6)[x], 
+                        "Implosion": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Pinch": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Punch": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "Shear": lambda x: torch.linspace(0, 1, 6)[x], 
+                        "PerspectiveWarp": lambda x: torch.linspace(0, 1, 6)[x] 
+                        }
+
+    def __call__(self, distortion_level=0, **kwargs): 
+        """
+        Parameters
+        ----------
+        distortion_level: int
+            The distortion effect from 0 to 5. 0 for identify function, 5 for max distortion as defined in the mapping function. 
+
+        Returns
+        -------
+        WarpTransform
+            The initialized object of WarpTransform with the given distortion level and keyword arguments. 
+        
+        Example Usage
+        -------------
+        swirl_transformer = SwirlController(1, radius=1) #or, SwirlController(distortion_level=1, radius=1) 
+        Args following distortion_level need to be keyword arguments. 
+        """
+        strength = self.mapping_dict[self.class_name](distortion_level)
+        return self.warp_transform(strength=strength, **kwargs)

--- a/torqueo/controller.py
+++ b/torqueo/controller.py
@@ -55,5 +55,6 @@ class WarpController():
         swirl_transformer = SwirlController(1, radius=1) #or, SwirlController(distortion_level=1, radius=1) 
         Args following distortion_level need to be keyword arguments. 
         """
+        assert 0<=distortion_level<=5
         strength = self.mapping_dict[self.class_name](distortion_level)
         return self.warp_transform(strength=strength, **kwargs)

--- a/torqueo/controller.py
+++ b/torqueo/controller.py
@@ -28,7 +28,7 @@ class WarpController():
                         "Stretching": lambda x: torch.linspace(0, 0.8, 6)[x], 
                         "Compression": lambda x: torch.linspace(0, 2, 6)[x], 
                         "Twirl": lambda x: torch.linspace(0, 1, 6)[x], 
-                        "Wave": lambda x: torch.linspace(1, 3, 6)[x], 
+                        "Wave": lambda x: torch.linspace(0, 1.5, 6)[x], 
                         "Spherize": lambda x: torch.linspace(0, 1.2, 6)[x], 
                         "Bulge": lambda x: torch.linspace(1, 3, 6)[x], 
                         "Implosion": lambda x: torch.linspace(0.5, 1, 6)[5-x], 

--- a/torqueo/transforms.py
+++ b/torqueo/transforms.py
@@ -337,7 +337,8 @@ class Wave(WarpTransform):
     """
     def __init__(self, strength = 1, amplitude=0.1, frequency=1.0, phase=0.0, axis='horizontal'):
         super(Wave, self).__init__()
-        self.amplitude = strength * amplitude
+        self.strength = strength
+        self.amplitude = amplitude
         self.frequency = frequency
         self.phase = phase
         assert axis in ['horizontal', 'vertical']
@@ -363,9 +364,9 @@ class Wave(WarpTransform):
 
         if self.axis == 'horizontal':
             x_new = x_indices
-            y_new = y_indices + self.amplitude * torch.sin(2 * torch.pi * self.frequency * x_indices + self.phase)
+            y_new = y_indices + self.strength * self.amplitude * torch.sin(2 * torch.pi * self.frequency * x_indices + self.phase)
         else:
-            x_new = x_indices + self.amplitude * torch.sin(2 * torch.pi * self.frequency * y_indices + self.phase)
+            x_new = x_indices + self.strength * self.amplitude * torch.sin(2 * torch.pi * self.frequency * y_indices + self.phase)
             y_new = y_indices
 
         # create the grid for warping

--- a/torqueo/transforms.py
+++ b/torqueo/transforms.py
@@ -168,7 +168,7 @@ class BarrelDistortion(WarpTransform):
 
         return grid
 
-class Pincusion(BarrelDistortion):
+class Pincushion(BarrelDistortion):
     """
     Applies a pincushion distortion effect, which is the inverse of barrel distortion.
 
@@ -184,7 +184,7 @@ class Pincusion(BarrelDistortion):
         The strength of the pincushion distortion effect.
     """
     def __init__(self, strength=0.5):
-        super(Pincusion, self).__init__(-strength)
+        super(Pincushion, self).__init__(-strength)
 
 class Stretching(WarpTransform):
     """

--- a/torqueo/transforms.py
+++ b/torqueo/transforms.py
@@ -663,25 +663,25 @@ class PerspectiveWarp(WarpTransform):
         y_indices, x_indices = torch.meshgrid(torch.linspace(-1, 1, height), torch.linspace(-1, 1, width))
 
         distortion_scale = self.strength
-        half_height = height // 2
-        half_width = width // 2
+        half_height = 1
+        half_width = 1
         topleft = [
-            int(torch.randint(0, int(distortion_scale * half_width) + 1, size=(1,)).item()),
-            int(torch.randint(0, int(distortion_scale * half_height) + 1, size=(1,)).item()),
+            -1 + distortion_scale*torch.rand(1).item(),
+            1 - distortion_scale*torch.rand(1).item(),
         ]
         topright = [
-            int(torch.randint(width - int(distortion_scale * half_width) - 1, width, size=(1,)).item()),
-            int(torch.randint(0, int(distortion_scale * half_height) + 1, size=(1,)).item()),
+            1 - distortion_scale*torch.rand(1).item(),
+            1 - distortion_scale*torch.rand(1).item(),
         ]
         botright = [
-            int(torch.randint(width - int(distortion_scale * half_width) - 1, width, size=(1,)).item()),
-            int(torch.randint(height - int(distortion_scale * half_height) - 1, height, size=(1,)).item()),
+            1 - distortion_scale*torch.rand(1).item(),
+            -1 + distortion_scale*torch.rand(1).item(),
         ]
         botleft = [
-            int(torch.randint(0, int(distortion_scale * half_width) + 1, size=(1,)).item()),
-            int(torch.randint(height - int(distortion_scale * half_height) - 1, height, size=(1,)).item()),
+            -1 + distortion_scale*torch.rand(1).item(),
+            -1 + distortion_scale*torch.rand(1).item(),
         ]
-        startpoints = [[0, 0], [width - 1, 0], [width - 1, height - 1], [0, height - 1]]
+        startpoints = [[-1, 1], [1, 1], [1, -1], [-1, -1]]
         endpoints = [topleft, topright, botright, botleft]
 
         a_matrix = torch.zeros(2 * len(startpoints), 8, dtype=torch.float64)

--- a/torqueo/transforms.py
+++ b/torqueo/transforms.py
@@ -162,6 +162,11 @@ class BarrelDistortion(WarpTransform):
         # angle dont' change
         x_new = r_d * torch.cos(theta)
         y_new = r_d * torch.sin(theta)
+        # scale to fill image
+        x_scale = min(1, 1/torch.max(torch.abs(x_new)))
+        y_scale = min(1, 1/torch.max(torch.abs(y_new)))
+        x_new = x_new*x_scale
+        y_new = y_new*y_scale
 
         grid = torch.stack((x_new, y_new), dim=-1)
         grid = grid.unsqueeze(0)
@@ -693,13 +698,3 @@ class PerspectiveWarp(WarpTransform):
         grid = torch.stack((x_new, y_new), dim=-1)
         grid = grid.unsqueeze(0)
         return grid
-
-    def forward(self, img):
-        assert img.dim() == 4
-
-        batch_size, channels, height, width = img.size()
-        grid = self.generate_warp_field(height, width)
-        grid = grid.to(img.device)
-
-        warped_img = F.grid_sample(img, grid, align_corners=True, mode='bilinear', padding_mode='zeros')
-        return warped_img

--- a/torqueo/transforms.py
+++ b/torqueo/transforms.py
@@ -319,11 +319,13 @@ class Wave(WarpTransform):
 
     Transformation
     --------------
-    y' = y + amplitude * sin(2 * pi * frequency * x + phase)  (if axis = 'horizontal')
-    x' = x + amplitude * sin(2 * pi * frequency * y + phase)  (if axis = 'vertical')
+    y' = y + strength * amplitude * sin(2 * pi * frequency * x + phase)  (if axis = 'horizontal')
+    x' = x + strength * amplitude * sin(2 * pi * frequency * y + phase)  (if axis = 'vertical')
 
     Parameters
     ----------
+    strength: float 
+        The strength of the distortion as defined by the scaling of the amplitude. 
     amplitude : float
         The amplitude of the wave.
     frequency : float
@@ -333,11 +335,9 @@ class Wave(WarpTransform):
     axis : str
         The axis along which to apply the wave effect ('horizontal' or 'vertical').
     """
-    def __init__(self, amplitude=0.1, frequency=1.0, phase=0.0, axis='horizontal'):
-        assert axis in ['x', 'y']
-
+    def __init__(self, strength = 1, amplitude=0.1, frequency=1.0, phase=0.0, axis='horizontal'):
         super(Wave, self).__init__()
-        self.amplitude = amplitude
+        self.amplitude = strength * amplitude
         self.frequency = frequency
         self.phase = phase
         assert axis in ['horizontal', 'vertical']

--- a/torqueo/transforms.py
+++ b/torqueo/transforms.py
@@ -542,9 +542,6 @@ class Pinch(WarpTransform):
         x_new = x_indices*pinch_factor
         y_new = y_indices*pinch_factor
 
-        x_new = x_new.clamp(-1, 1)
-        y_new = y_new.clamp(-1, 1)
-
         grid = torch.stack((x_new, y_new), dim=-1)
         grid = grid.unsqueeze(0)
         return grid
@@ -614,9 +611,6 @@ class Shear(WarpTransform):
         else:
             x_new = x_indices
             y_new = self.strength*x_indices + y_indices
-
-        x_new = x_new.clamp(-1, 1)
-        y_new = y_new.clamp(-1, 1)
 
         grid = torch.stack((x_new, y_new), dim=-1)
         grid = grid.unsqueeze(0)
@@ -695,8 +689,6 @@ class PerspectiveWarp(WarpTransform):
         #(x, y) -> ( (ax + by + c) / (gx + hy + 1), (dx + ey + f) / (gx + hy + 1) )
         x_new = (res[0]*x_indices + res[1]*y_indices + res[2])/(res[6]*x_indices + res[7]*y_indices + 1)
         y_new = (res[3]*x_indices + res[4]*y_indices + res[5])/(res[6]*x_indices + res[7]*y_indices + 1)
-        x_new = x_new.clamp(-1, 1)
-        y_new = y_new.clamp(-1, 1)
 
         grid = torch.stack((x_new, y_new), dim=-1)
         grid = grid.unsqueeze(0)

--- a/torqueo/transforms.py
+++ b/torqueo/transforms.py
@@ -192,8 +192,8 @@ class Stretching(WarpTransform):
 
     Transformation
     --------------
-    x' = x * (1 + strength)  (if axis = 'horizontal')
-    y' = y * (1 + strength)  (if axis = 'vertical')
+    x' = x * (1 - strength)  (if axis = 'horizontal')
+    y' = y * (1 - strength)  (if axis = 'vertical')
 
     Parameters
     ----------
@@ -228,11 +228,11 @@ class Stretching(WarpTransform):
         y_indices, x_indices = torch.meshgrid(torch.linspace(-1, 1, height), torch.linspace(-1, 1, width))
 
         if self.axis == 'horizontal':
-            x_new = x_indices * (1 + self.strength)
+            x_new = x_indices * (1 - self.strength)
             y_new = y_indices
         else:
             x_new = x_indices
-            y_new = y_indices * (1 + self.strength)
+            y_new = y_indices * (1 - self.strength)
 
         # create the grid for warping
         grid = torch.stack((x_new, y_new), dim=-1)
@@ -246,8 +246,8 @@ class Compression(Stretching):
 
     Transformation
     --------------
-    x' = x * (1 - strength)  (if axis = 'horizontal')
-    y' = y * (1 - strength)  (if axis = 'vertical')
+    x' = x * (1 + strength)  (if axis = 'horizontal')
+    y' = y * (1 + strength)  (if axis = 'vertical')
 
     Parameters
     ----------


### PR DESCRIPTION
Common class to control the level of warping by using a **distortion level (0 to 5)** along with the regular keyword arguments for each transform. The distortion level is mapped to a linear scale of "reasonable" strength for each transform. 

TODO: 
Qualitative Check for the scale/range of deformation strength for each transform. 

Associated notebook: https://colab.research.google.com/drive/1THzKL_32PHXKhEOGri5yci3oEz9sKrqx?usp=drive_link 

Bugfix: 
1. **Barrel**: Too much 0 padding around the edges of the distorted image. Fixed by scaling down the x_new, y_new to fit to [-1,1]. 
2. **Perspective** transform: Sampling grid range bug fixed. Stretching type artifact on edges removed. 
3. **Punch**: Assertion error due to negative strength and class inheritance fixed. Stretching type artifact corrected. 
4. **Implosion**: Fixed assertion error. Fixed distortion to strength mapping in the controller. 
5. **Spherize**: Identity transform (deform=0) was breaking. 
6. **Stretching** and Compression: The behavior was the reverse of the desired behavior, fixed that. 
7. **Shear**: Stretching (clamp-related) bug removed. 