### PR TITLE
bugfix: pinch and punch had unrequired strength param constraint

### DIFF
--- a/torqueo/transforms.py
+++ b/torqueo/transforms.py
@@ -580,12 +580,11 @@ class Pinch(WarpTransform):
     Parameters
     ----------
     strength : float
-        The strength of the pinch distortion effect. Must be between 0.0 and 1.0.
+        The strength of the pinch distortion effect.
     """
 
     def __init__(self, strength=0.5):
         super().__init__()
-        assert 0.0 <= abs(strength) <= 1.0
         self.strength = strength
 
     def generate_warp_field(self, height, width):
@@ -635,7 +634,7 @@ class Punch(Pinch):
     Parameters
     ----------
     strength : float
-        The strength of the punch distortion effect. Must be between 0.0 and 1.0.
+        The strength of the punch distortion effect.
     """
 
     def __init__(self, strength=0.5):


### PR DESCRIPTION
Pinch and Punch had an assert check for abs(strength) to be within [0,1] which isn't a logical or runtime safety requirement. 